### PR TITLE
DEVOPS-1697:fix(cloudformation templates): correct handling of Fn::Join with Fn::Split [DM]

### DIFF
--- a/lib/cloudformation-ruby-dsl/cfntemplate.rb
+++ b/lib/cloudformation-ruby-dsl/cfntemplate.rb
@@ -99,7 +99,7 @@ def parse_args
     when '--stack-name'
       args[:stack_name] = value
     when '--parameters'
-      args[:parameters] = Hash[value.split(/;/).map { |pair| parts = pair.split(/=/, 2); [ parts[0], Parameter.new(parts[1]) ] }]
+      args[:parameters] = Hash[value.split(/;/).map { |pair| parts = pair.split(/=/, 2); [ parts[0], TemplateParameter.new(parts[1]) ] }]
     when '--interactive'
       args[:interactive] = true
     when '--region'
@@ -553,7 +553,7 @@ template.rb create --stack-name my_stack --parameters "BucketName=bucket-s3-stat
               if !immutables_exist && new_parameters[param].empty?
                 $stderr.puts "Using previous parameter " +
                                  "'#{param}=#{old_parameters[param]}'."
-                new_parameters[param] = Parameter.new(old_parameters[param])
+                new_parameters[param] = TemplateParameter.new(old_parameters[param])
                 new_parameters[param].use_previous_value = true
               end
             end
@@ -706,7 +706,7 @@ end
 def apply_parameter_defaults(parameters)
   parameters.each do |k, v|
     if v.empty?
-      parameters[k] = Parameter.new(v.default)
+      parameters[k] = TemplateParameter.new(v.default)
       $stderr.puts "Using default parameter value " +
                        "'#{k}=#{parameters[k]}'."
     end

--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -286,7 +286,13 @@ def join(delim, *list)
 end
 
 # Variant of join that matches the native CFN syntax.
-def join_list(delim, list) { :'Fn::Join' => [ delim, list ] } end
+def join_list(delim, list)
+  if list.length == 1
+    { :'Fn::Join' => [ delim, list[0] ] }
+  else
+    { :'Fn::Join' => [ delim, list ] }
+  end
+end
 
 def equal(one, two) { :'Fn::Equals' => [one, two] } end
 

--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -52,7 +52,7 @@ def default_region
   ENV['EC2_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'us-east-1'
 end
 
-class Parameter < String
+class TemplateParameter < String
   attr_accessor :default, :use_previous_value
 
   def initialize string
@@ -89,9 +89,9 @@ class TemplateDSL < JsonObjectDSL
     default(:Parameters, {})[name] = options
 
     if @interactive
-      @parameters[name] ||= Parameter.new(_get_parameter_from_cli(name, options))
+      @parameters[name] ||= TemplateParameter.new(_get_parameter_from_cli(name, options))
     else
-      @parameters[name] ||= Parameter.new('')
+      @parameters[name] ||= TemplateParameter.new('')
     end
 
     # set various param options


### PR DESCRIPTION
when cloudformation-ruby-dsl sees the ruby expression
```join(delim, "str1", "str2",....)``` 
it (correctly) converts it to the json 
```Fn::Join[delim,["str1", "str2", ...]]```. 
However, `Fn::Join` also accepts a *single* *function* argument that returns a list of strings, e.g. `Fn::Split`. cloudformation-ruby-dsl incorrectly converts a single function argument into a list, e.g. 
```join(delim1, split(delim2, expr))``` 
becomes 
```Fn::Join[delim1, [{Fn::Split[delim2, expr]}]]``` 
when it should instead be
```Fn::Join[delim1, {Fn::Split[delim2, expr]}]```. 
This fails AWS validation, resulting in the message ```An error occurred (ValidationError) when calling the CreateStack operation: Template error: every Fn::Join object requires two parameters, (1) a string delimiter and (2) a list of strings to be joined or a function that returns a list of strings (such as Fn::GetAZs) to be joined. ```
This PR provides a fix for the *specific* case where a single argument arg is supplied to `join(delim,arg)`, in which case the single argument is not converted into a list, but passed directly to `Fn::Join[delim, arg]`. 
TODO: refine the solution to cater for the general case of nested intrinsic functions.