### PR TITLE
Fixes [DM]

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ Make the resulting file executable (`chmod +x [NEW_NAME.rb]`). It can respond to
 - `get-template`: get entire template output of an existing stack
 
 Command line options similar to cloudformation commands, but parsed by the dsl.
-- `--profile`
 - `--stack-name`
-- `--region`
 - `--parameters`
 - `--tag`
 
@@ -122,10 +120,6 @@ Additional capabilities for file inclusion, etc.
 - `load_from_file(filename)`: load the named file by a given type; currently handles YAML, JSON, and Ruby
 - `interpolate(string)`: embed CFN references into a string (`{{ref('Service')}}`) for later interpretation by the CFN engine
 - `Table.load(filename)`: load a table from the listed file, which can then be turned into mappings (via `get_map`)
-
-### Default Region
-
-The tool defaults to region `us-east-1`. To change this set either `EC2_REGION` or `AWS_DEFAULT_REGION` in your environment.
 
 ## Usage as a library
 

--- a/examples/simple_template.rb
+++ b/examples/simple_template.rb
@@ -5,10 +5,10 @@ require 'cloudformation-ruby-dsl/cfntemplate'
 
 extension = File.join(__dir__, "simple_template_extension.rb")
 
-dsl = TemplateDSL.new({region: 'eu-west-1'}, [ extension ])
+dsl = TemplateDSL.new({}, extension)
 # equivalent to:
 # 
-# dsl = TemplateDSL.new({region: 'eu-west-1'})
+# dsl = TemplateDSL.new({})
 # dsl.load_from_file(extension)
 
 

--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -44,11 +44,7 @@ end
 
 # Main entry point
 def raw_template(options = {}, &block)
-  TemplateDSL.new(options, extensions = []).template(&block)
-end
-
-def default_region
-  ENV['EC2_REGION'] || ENV['AWS_DEFAULT_REGION'] || 'us-east-1'
+  TemplateDSL.new(options).template(&block)
 end
 
 class TemplateParameter < String
@@ -61,20 +57,17 @@ end
 
 # Core interpreter for the DSL
 class TemplateDSL < JsonObjectDSL
+
   attr_reader :parameters,
               :parameter_cli,
-              :aws_region,
               :nopretty,
               :stack_name,
-              :aws_profile,
               :s3_bucket
 
   def initialize(options, extensions = [])
     @parameters  = options.fetch(:parameters, {})
     @interactive = options.fetch(:interactive, false)
     @stack_name  = options[:stack_name]
-    @aws_region  = options.fetch(:region, default_region)
-    @aws_profile = options[:profile]
     @nopretty    = options.fetch(:nopretty, false)
     @s3_bucket   = options.fetch(:s3_bucket, nil)
     super()
@@ -278,6 +271,9 @@ def get_azs(region = '') { :'Fn::GetAZs' => region } end
 
 def import_value(value) { :'Fn::ImportValue' => value } end
 
+def aws_region
+  ref("AWS::Region")
+end
 # There are two valid forms of Fn::Sub, with a map and without.
 def sub(sub_string, var_map = {})
   if var_map.empty?

--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -64,14 +64,14 @@ class TemplateDSL < JsonObjectDSL
               :stack_name,
               :s3_bucket
 
-  def initialize(options, extensions = [])
+  def initialize(options, *extensions)
     @parameters  = options.fetch(:parameters, {})
     @interactive = options.fetch(:interactive, false)
     @stack_name  = options[:stack_name]
     @nopretty    = options.fetch(:nopretty, false)
     @s3_bucket   = options.fetch(:s3_bucket, nil)
     super()
-    load_extensions(extensions)
+    load_extensions(*extensions)
   end
 
   def exec!()
@@ -120,7 +120,7 @@ class TemplateDSL < JsonObjectDSL
     end
   end
 
-  def load_extensions(extensions = [])
+  def load_extensions(*extensions)
     extensions.each { |e| load_from_file(e) }
   end
   

--- a/lib/cloudformation-ruby-dsl/dsl.rb
+++ b/lib/cloudformation-ruby-dsl/dsl.rb
@@ -370,20 +370,11 @@ def join_interpolate(delim, string)
   interpolate(string)
 end
 
-# This class is used by erb templates so they can access the parameters passed
-class Namespace
-  attr_accessor :params
-  def initialize(hash)
-    @params = hash
-  end
-  def get_binding
-    binding
-  end
-end
-
 # Combines the provided ERB template with optional parameters
 def erb_template(filename, params = {})
-  ERB.new(file(filename), nil, '-').result(Namespace.new(params).get_binding)
+  erb = ERB.new(file(filename), nil, '-')
+  erb.filename = filename
+  erb.result_with_hash(params: params)
 end
 
 def warn_deprecated(old, new)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -144,22 +144,10 @@ module AwsHelpers
     end
   end
 
-  def profile
-    ENV["AWS_PROFILE"] || "default"
-  end
-
-  def region
-    ENV["AWS_REGION"] || "us-east-1"
-  end
-
   private
 
   def validation_command(template_path)
-    return <<-EOF
-      aws cloudformation validate-template --template-body file://#{template_path} \
-                                           --region #{region} \
-                                           --profile #{profile}
-    EOF
+    "aws cloudformation validate-template --template-body file://#{template_path}"
   end
 end
 
@@ -167,7 +155,7 @@ end
 class RspecHelpers
   class << self
     def cloudformation
-      @_cloudformation_ ||= ::Aws::CloudFormation::Client.new(region: region, profile: profile)
+      @_cloudformation_ ||= ::Aws::CloudFormation::Client.new
     end
   end
 end


### PR DESCRIPTION
- removes all code which is to do with setting AWS credentials / region

These 2 are needed in https://github.com/citizensadvice/cloudformaton-templates

- fix: templates rendered with `erb_file` can't determine `__dir__`
- fix: extensions loaded with `load_from_file` can't determine which file are they loaded from